### PR TITLE
Fix: Remove "genre" key from Fuzzy Search

### DIFF
--- a/src/hooks/useFuzzySearchMovies.ts
+++ b/src/hooks/useFuzzySearchMovies.ts
@@ -13,7 +13,7 @@ const useFuzzySearchMovies = (searchPattern?: string, limit?: number) => {
     getMovies().then(moviesData => {
       const fuseOptions = {
         includeScore: true,
-        keys: ['title', 'genre'],
+        keys: ['title'],
       };
       const currentFuse = new Fuse(moviesData, fuseOptions);
       setFuse(currentFuse);


### PR DESCRIPTION
- Removed "genre" key from the fuzzy search, it should use only the "title" key